### PR TITLE
Rename _N to avoid conflict with C Standard Library's ctype.h

### DIFF
--- a/src/FLashDLL.cpp
+++ b/src/FLashDLL.cpp
@@ -225,8 +225,8 @@ extern "C" SEXPDLLExport AdaptFuncAD(SEXP xStock, SEXP xFitPlusGroup, SEXP xFrat
    for (iage=q.minquant(); iage<=q.maxquant(); iage++)
      for (iyr=index.minyr(); iyr<=index.maxyr(); iyr++)
        {
-       adouble _N = VPA.N_ad(iage,iyr)*q_ad(iage,q.minyr(),1,1,1,1); 
-       ss_ad += pow((index(iage,iyr)-_N)/_N,2.0);
+       adouble N = VPA.N_ad(iage,iyr)*q_ad(iage,q.minyr(),1,1,1,1); 
+       ss_ad += pow((index(iage,iyr)-N)/N,2.0);
        } 
    //end calculate objective function
 
@@ -280,8 +280,8 @@ extern "C" SEXPDLLExport AdaptGrad(SEXP xStock, SEXP xFitPlusGroup, SEXP xFratio
       for (iage=q.minquant(); iage<=q.maxquant(); iage++)
            for (iage=q.minquant(), i=0; iage<=q.maxquant(); iage++, i++)
            {
-           adouble _N = VPA.N_ad(iage,iyr)*q_ad(iage,q.minyr(),1,1,1,1); 
-           ss_ad += pow((index(iage,iyr)-_N)/_N,2.0);
+           adouble N = VPA.N_ad(iage,iyr)*q_ad(iage,q.minyr(),1,1,1,1); 
+           ss_ad += pow((index(iage,iyr)-N)/N,2.0);
            } 
 
       ss_ad /= (index.minquant()-index.minquant()+1)*(index.maxquant()-index.minquant()+1);
@@ -355,8 +355,8 @@ extern "C" SEXPDLLExport AdaptSetupTape(SEXP xStock, SEXP xFitPlusGroup, SEXP xF
       for (iyr=index.minyr(); iyr<=index.maxyr(); iyr++)
          for (iage=q.minquant(); iage<=q.maxquant(); iage++)
            {
-           adouble _N = VPA.N_ad(iage,iyr)*q_ad(iage,q.minyr(),1,1,1,1); 
-           ss_ad += pow((index(iage,iyr)-_N)/_N,2.0);
+           adouble N = VPA.N_ad(iage,iyr)*q_ad(iage,q.minyr(),1,1,1,1); 
+           ss_ad += pow((index(iage,iyr)-N)/N,2.0);
            } 
 
       ss_ad /= (index.minquant()-index.minquant()+1)*(index.maxquant()-index.minquant()+1);

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -20,7 +20,7 @@ all: $(SHLIB)
 
 sublibs: subclean
 	@for d in $(SUBDIRS); do \
-	  (cd $${d} && CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" MkInclude="$(MkInclude)" $(MAKE) library) || exit 1; \
+	  (cd $${d} && CC="$(CC)" CXX="$(CXX)" AR="$(AR)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" MkInclude="$(MkInclude)" $(MAKE) library) || exit 1; \
 	done
 
 clean: subclean


### PR DESCRIPTION
Fixes compilation on OpenBSD, and possibly other BSDs.
Tested on OpenBSD, macOS